### PR TITLE
Persistent Connections to the hyperic server

### DIFF
--- a/hqapi1/src/main/java/org/hyperic/hq/hqapi1/FileResponseHandler.java
+++ b/hqapi1/src/main/java/org/hyperic/hq/hqapi1/FileResponseHandler.java
@@ -104,6 +104,13 @@ public class FileResponseHandler<T> implements ResponseHandler<T> {
 				_log.warn("Unable to deserialize result", e);
 				return getErrorResponse(error);
 			} finally {
+				if (in != null) {
+					try {
+						in.close();
+					} catch (IOException e) {
+						_log.warn("Unable to close response stream. Cause: " + e.getMessage());
+					}
+				}
 				if (fileOutputStream != null) {
 					try {
 						fileOutputStream.close();

--- a/hqapi1/src/main/java/org/hyperic/hq/hqapi1/XmlResponseHandler.java
+++ b/hqapi1/src/main/java/org/hyperic/hq/hqapi1/XmlResponseHandler.java
@@ -48,6 +48,14 @@ public class XmlResponseHandler<T> implements ResponseHandler<T> {
                         _log.debug("Unable to deserialize result", e);
                     }
                     return getErrorResponse(error);
+                } finally {
+                    if (is != null) {
+                        try {
+                                is.close();
+                        } catch (IOException e) {
+                                _log.warn("Unable to close XML response stream. Cause: " + e.getMessage());
+                        }
+                    }
                 }
             case 401:
                 // Unauthorized


### PR DESCRIPTION
Hi all,

The original purpose of this was to minimize http session creation at the server so the hyperic server memory won't get blown (without any changes to existing hyperic servers). This fix achieves that by combining persistent connections with limiting the maximum concurrent connections being opened.

Based on the 4.2 tag (will be added to other releases after approval).

(sorry if something is wrong git-wise... I'm just learning git).

thanks a lot,
RL

Commit message:
Requests to the server are done using multiple persistent connections. Thread safe. In addition, the response handlers now make sure that the response streams are closed after reading the response.
